### PR TITLE
Fix case of version and verbose option alias in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ CLI usage
     [required] github personal access token
   - `-c, --config`
     [required] path to config file
-  - `-V, --verbose`
+  - `-v, --verbose`
     make output more verbose
   - `-s, --silent`
     oppress output
-  - `-v, --version`
+  - `-V, --version`
     output version
   - `-h, --help`
     output help message


### PR DESCRIPTION
According to https://github.com/Jimdo/github-sync-labels-milestones/blob/master/cli.js#L10-L11, `-V` is an alias for `--version` and `-v` for `--verbose`.
