### PR TITLE
mention required milesstone key

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ an array of configuration objects.
 
   - #### `milestones`
 
-    _optional_ Array of milestones that should be synchronized
+    Array of milestones that should be synchronized
 
   - #### `labels` 
 


### PR DESCRIPTION
When running w/o milestone option the script crashes with the following error:

```
👌  jimdo-template-design-werkstatt git:(master) ✗ github-sync-labels-milestones -t $GH_TOKEN -c github-lables.json -v
TypeError: Cannot read property 'forEach' of undefined
TypeError: Cannot read property 'forEach' of undefined
    at /usr/local/lib/node_modules/github-sync-labels-milestones/lib/index.js:43:20
    at Array.forEach (native)
    at validateInstruction (/usr/local/lib/node_modules/github-sync-labels-milestones/lib/index.js:42:5)
    at /usr/local/lib/node_modules/github-sync-labels-milestones/lib/index.js:79:5
    at Array.forEach (native)
    at sync (/usr/local/lib/node_modules/github-sync-labels-milestones/lib/index.js:78:16)
    at /usr/local/lib/node_modules/github-sync-labels-milestones/cli.js:87:32
    at _fulfilled (/usr/local/lib/node_modules/github-sync-labels-milestones/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done (/usr/local/lib/node_modules/github-sync-labels-milestones/node_modules/q/q.js:863:30)
    at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/github-sync-labels-milestones/node_modules/q/q.js:796:13)
```

cheers :sparkles: 
