### PR TITLE
add --disable-follow parameter for GitHub API

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -41,13 +41,14 @@ if (argv.help) {
     '',
     'Options:',
     '',
-    '  ' + chalk.yellow('-t, --token') + '   [required] github personal access token',
-    '  ' + chalk.yellow('-c, --config') + '  [required] path to config file',
-    '  ' + chalk.yellow('-V, --verbose') + ' make output more verbose',
-    '  ' + chalk.yellow('-s, --silent') + '  oppress output',
-    '  ' + chalk.yellow('-v, --version') + ' output version',
-    '  ' + chalk.yellow('-h, --help') + '    output help message',
-    '  ' + chalk.yellow('--no-color') + '    disable colors',
+    '  ' + chalk.yellow('-t, --token') + '      [required] github personal access token',
+    '  ' + chalk.yellow('-c, --config') + '     [required] path to config file',
+    '  ' + chalk.yellow('-V, --verbose') + '    make output more verbose',
+    '  ' + chalk.yellow('-s, --silent') + '     oppress output',
+    '  ' + chalk.yellow('-v, --version') + '    output version',
+    '  ' + chalk.yellow('-h, --help') + '       output help message',
+    '  ' + chalk.yellow('--no-color') + '       disable colors',
+    '  ' + chalk.yellow('--disable-follow') + ' disable redirects (sometimes causes issues with GitHub API)',
     '',
     chalk.gray('Get a personal access token here: https://github.com/settings/tokens'),
     chalk.gray('[repo] and [public_repo] scopes need to be activated')
@@ -100,7 +101,8 @@ function getConfig() {
 Q.fcall(getConfig).then(function(config) {
   return require('./lib/index')({
     token: argv.token,
-    log: logger
+    log: logger,
+    followRedirects: !argv['disable-follow']
   }, config);
 }).then(function() {
   _.forEach(logs, function(states, type) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,12 +9,13 @@ function validateOptions(options) {
   }
 }
 
-function getGitHub(token) {
+function getGitHub(token, followRedirects) {
   var github = new GitHubApi({
     version: '3.0.0',
     headers: {
       'user-agent': 'Jimdo/github-sync-labels-milestones'
-    }
+    },
+    followRedirects: followRedirects
   });
 
   github.authenticate({
@@ -76,7 +77,7 @@ function validateInstruction(rules) {
 module.exports = function sync(options, instructions) {
   validateOptions(options);
 
-  var github = getGitHub(options.token);
+  var github = getGitHub(options.token, options.followRedirects);
   var queue = [];
 
   [].concat(instructions).forEach(function(instruction) {


### PR DESCRIPTION
The `github` package allows for setting `followRedirects: false` (defaults to `true`) to fix sometimes failing redirects for non-get requests. 

This PR adds a command line option `--disable-follow` that allows setting this flag 

See https://github.com/mikedeboer/node-github/issues/345