### PR TITLE
Throttle github client within rate/abuse limits

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Bottleneck = require('bottleneck');
 var GitHubApi = require('github');
 var Q = require('q');
 
@@ -7,6 +8,17 @@ function validateOptions(options) {
   if (!options || !options.token) {
     throw new Error('github token required');
   }
+}
+
+// Hack client to only allow one request at a time with a 1s delay
+// https://github.com/mikedeboer/node-github/issues/526
+function rateLimitedClient(github) {
+  const limiter = new Bottleneck(1, 1000);
+  const oldHandler = github.handler;
+  github.handler = (msg, block, callback) => {
+    limiter.submit(oldHandler.bind(github), msg, block, callback);
+  };
+  return github;
 }
 
 function getGitHub(token, options) {
@@ -22,7 +34,7 @@ function getGitHub(token, options) {
     token: token
   });
 
-  return github;
+  return rateLimitedClient(github);
 }
 
 function validateInstruction(rules) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "github-sync-labels-milestones": "./cli.js"
   },
   "dependencies": {
+    "bottleneck": "1.16.0",
     "chalk": "1.1.3",
     "github": "3.0.0",
     "lodash": "4.15.0",


### PR DESCRIPTION
I cribbed the probot approach for throttling https://github.com/probot/probot/pull/109 .  I tested our config, which was consistently failing, and it now succeeds without issue.

Closes #14

<https://developer.github.com/v3/guides/best-practices-for-integrators>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xiphe/github-sync-labels-milestones/15)
<!-- Reviewable:end -->
