### PR TITLE
docs(readme): improve token description

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ CLI usage
 ### Options
 
   - `-t, --token`  
-    [required] github personal access token
+    [required] [github personal access token with repo access](https://github.com/settings/tokens/new)
   - `-c, --config`  
     [required] path to config file
   - `-v, --verbose`  

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ an array of configuration objects.
 ```
 
 ### configuration object shape
-  
+
   - #### `repositories`
 
     Array of repositories on which the labels and milestones
@@ -95,7 +95,7 @@ an array of configuration objects.
 
     Array of milestones that should be synchronized
 
-  - #### `labels` 
+  - #### `labels`
 
     _optional_ Array of labels that should be synchronized
 
@@ -113,7 +113,7 @@ an array of configuration objects.
   - #### `previousTitles`
 
     _optional_ Array of titles this milestone had before.
-    We will try to __rename__ milestones found here to `title` 
+    We will try to __rename__ milestones found here to `title`
     instead of creating a new one
 
   - #### `state`
@@ -129,7 +129,7 @@ an array of configuration objects.
 
     _optional_ The milestone due date. This is a timestamp in ISO 8601 format:  
     `YYYY-MM-DDTHH:MM:SSZ`
- 
+
 
 ### label declaration shape
 
@@ -168,20 +168,20 @@ LICENSE
 -------
 
 > The MIT License
-> 
+>
 > Copyright (c) 2017 Hannes Diercks  
 > Copyright (c) 2015 - 2016 Jimdo GmbH
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
This makes the usage a tiny bit more accessible. 

Also introduces formating according to the editorconfig